### PR TITLE
Add react-icons dependency to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "react-icons": "^5.5.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Purpose
Fix build failure caused by missing `react-icons` dependency. The build was failing because the TVScreen component was importing from "react-icons/fa" but the package wasn't installed, causing Rollup to fail during the build process.

## Code changes
- Added `react-icons` version `^5.5.0` to package.json dependencies
- This resolves the import error for "react-icons/fa" in TVScreen.tsx component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f4597e3070494029a66fa957a8ede4f3/pulse-lab)

👀 [Preview Link](https://f4597e3070494029a66fa957a8ede4f3-pulse-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f4597e3070494029a66fa957a8ede4f3</projectId>-->
<!--<branchName>pulse-lab</branchName>-->